### PR TITLE
free the memory allocated for the buffer

### DIFF
--- a/bitsery/bitsery.cpp
+++ b/bitsery/bitsery.cpp
@@ -64,7 +64,7 @@ class BitseryArchiver : public ISerializerTest {
 public:
 
     Buf serialize(const std::vector<MyTypes::Monster> &data) override {
-        _buf.clear();
+        _buf = Buffer{};
         bitsery::Serializer<OutputAdapter> ser(_buf);
         ser.container(data, 100000000);
         ser.adapter().flush();

--- a/bitsery/bitsery_brief_syntax.cpp
+++ b/bitsery/bitsery_brief_syntax.cpp
@@ -64,7 +64,7 @@ class BitseryVerboseSyntaxArchiver : public ISerializerTest {
 public:
 
     Buf serialize(const std::vector<MyTypes::Monster> &data) override {
-        _buf.clear();
+        _buf = Buffer{};
         bitsery::Serializer<OutputAdapter> ser(_buf);
         ser.container(data, 100000000);
         ser.adapter().flush();

--- a/bitsery/bitsery_compatibility.cpp
+++ b/bitsery/bitsery_compatibility.cpp
@@ -73,7 +73,7 @@ class BitseryCompatibilityArchiver : public ISerializerTest {
 public:
 
     Buf serialize(const std::vector<MyTypes::Monster> &data) override {
-        _buf.clear();
+        _buf = Buffer{};
         bitsery::Serializer<OutputAdapter> ser{_buf};
         ser.container(data, 100000000);
         ser.adapter().flush();

--- a/bitsery/bitsery_compression.cpp
+++ b/bitsery/bitsery_compression.cpp
@@ -69,7 +69,7 @@ class BitseryCompressionArchiver : public ISerializerTest {
 public:
 
     Buf serialize(const std::vector<MyTypes::Monster> &data) override {
-        _buf.clear();
+        _buf = Buffer{};
         bitsery::Serializer<OutputAdapter> ser(_buf);
         ser.container(data, 100000000);
         ser.adapter().flush();

--- a/bitsery/bitsery_unsafe_read.cpp
+++ b/bitsery/bitsery_unsafe_read.cpp
@@ -70,8 +70,7 @@ class BitseryUnsafeArchiver : public ISerializerTest {
 public:
 
     Buf serialize(const std::vector<MyTypes::Monster> &data) override {
-        _buf.clear();
-
+        _buf = Buffer{};
         bitsery::Serializer<OutputAdapter> ser(_buf);
         ser.container(data, 100000000);
         ser.adapter().flush();

--- a/yas/CMakeLists.txt
+++ b/yas/CMakeLists.txt
@@ -3,8 +3,8 @@ set(yas_INCLUDE ${yas_PREFIX}/src/yas_dep/include)
 ExternalProject_Add(
         yas_dep
         PREFIX ${yas_PREFIX}
-        URL "https://github.com/niXman/yas/archive/7.0.2.tar.gz"
-        URL_MD5 "d55353960467afabc6774583880a30f0"
+        URL "https://github.com/niXman/yas/archive/7.0.4.tar.gz"
+        URL_MD5 "e548556552d5a8d3aa634eda1621d027"
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ""

--- a/yas/yas.cpp
+++ b/yas/yas.cpp
@@ -21,9 +21,7 @@
 //SOFTWARE.
 
 #include <testing/test.h>
-#include <yas/mem_streams.hpp>
-#include <yas/binary_iarchive.hpp>
-#include <yas/binary_oarchive.hpp>
+#include <yas/serialize.hpp>
 #include <yas/types/std/vector.hpp>
 #include <yas/types/std/string.hpp>
 
@@ -51,21 +49,13 @@ class YasArchiver : public ISerializerTest {
 public:
 
     Buf serialize(const std::vector<MyTypes::Monster> &data) override {
-        yas::mem_ostream os;
-        yas::binary_oarchive<yas::mem_ostream, yas::binary | yas::no_header> oa(os);
-        oa & data;
-        if (_buf.size == 0)
-            _buf = os.get_shared_buffer();
+        _buf = yas::save<yas::mem | yas::binary | yas::no_header>(data);
 
         return {reinterpret_cast<const uint8_t *>(_buf.data.get()), _buf.size};
     }
 
     void deserialize(Buf buf, std::vector<MyTypes::Monster> &resVec) override {
-
-        yas::mem_istream is(buf.ptr, buf.bytesCount);
-        yas::binary_iarchive<yas::mem_istream, yas::binary | yas::no_header> ia(is);
-
-        ia & resVec;
+        yas::load<yas::mem | yas::binary | yas::no_header>(_buf, resVec);
     }
 
     TestInfo testInfo() const override {

--- a/yas/yas_compression.cpp
+++ b/yas/yas_compression.cpp
@@ -22,9 +22,7 @@
 
 #include <testing/test.h>
 
-#include <yas/mem_streams.hpp>
-#include <yas/binary_iarchive.hpp>
-#include <yas/binary_oarchive.hpp>
+#include <yas/serialize.hpp>
 #include <yas/types/std/vector.hpp>
 #include <yas/types/std/string.hpp>
 
@@ -52,21 +50,13 @@ class YasArchiverCompression : public ISerializerTest {
 public:
 
     Buf serialize(const std::vector<MyTypes::Monster> &data) override {
-        yas::mem_ostream os;
-        yas::binary_oarchive<yas::mem_ostream, yas::binary | yas::no_header | yas::compacted> oa(os);
-        oa & data;
-        if (_buf.size == 0)
-            _buf = os.get_shared_buffer();
+        _buf = yas::save<yas::mem | yas::binary | yas::no_header | yas::compacted>(data);
 
         return {reinterpret_cast<const uint8_t *>(_buf.data.get()), _buf.size};
     }
 
     void deserialize(Buf buf, std::vector<MyTypes::Monster> &resVec) override {
-
-        yas::mem_istream is(buf.ptr, buf.bytesCount);
-        yas::binary_iarchive<yas::mem_istream, yas::binary | yas::no_header | yas::compacted> ia(is);
-
-        ia & resVec;
+        yas::load<yas::mem | yas::binary | yas::no_header | yas::compacted>(_buf, resVec);
     }
 
     TestInfo testInfo() const override {

--- a/yas/yas_sstream.cpp
+++ b/yas/yas_sstream.cpp
@@ -23,11 +23,7 @@
 #include <testing/test.h>
 
 #include <sstream>
-#include <yas/std_streams.hpp>
-
-#include <yas/binary_iarchive.hpp>
-#include <yas/binary_oarchive.hpp>
-//#include <yas/std_types.hpp>
+#include <yas/serialize.hpp>
 #include <yas/types/std/vector.hpp>
 #include <yas/types/std/string.hpp>
 
@@ -57,30 +53,28 @@ public:
     Buf serialize(const std::vector<MyTypes::Monster> &data) override {
         std::stringstream ss;
         yas::std_ostream_adapter os{ss};
-        yas::binary_oarchive<yas::std_ostream_adapter, yas::binary | yas::no_header> oa(os);
-        oa & data;
+        yas::save<yas::file | yas::binary | yas::no_header>(os, data);
 
         if (_buf.empty())
             _buf = ss.str();
+
         return {
-                reinterpret_cast<uint8_t *>(std::addressof(*_buf.begin())),
-                _buf.size()
+            reinterpret_cast<uint8_t *>(std::addressof(*_buf.begin())),
+            _buf.size()
         };
     }
 
     void deserialize(Buf buf, std::vector<MyTypes::Monster> &resVec) override {
         std::stringstream ss{_buf};
         yas::std_istream_adapter is(ss);
-        yas::binary_iarchive<yas::std_istream_adapter, yas::binary | yas::no_header> ia(is);
-
-        ia & resVec;
+        yas::load<yas::file | yas::binary | yas::no_header>(is, resVec);
     }
 
     TestInfo testInfo() const override {
         return {
-                SerializationLibrary::YAS,
-                "stream",
-                "using std::stringstream"
+            SerializationLibrary::YAS,
+            "stream",
+            "using std::stringstream"
         };
     }
 


### PR DESCRIPTION
free the memory allocated for the buffer for each serialization.

because `vector::clear()` does not free internal area as pointed in [reference](https://en.cppreference.com/w/cpp/container/vector/clear):

> Erases all elements from the container. After this call, size() returns zero.
> 
> Invalidates any references, pointers, or iterators referring to contained elements. Any past-the-end iterators are also invalidated.  
> 
> **Leaves the capacity() of the vector unchanged** (note: the standard's restriction on the changes to capacity is in the specification of vector::reserve, see [1]) 
> 

so also need to call [`shrink_to_fit()`](https://en.cppreference.com/w/cpp/container/vector/shrink_to_fit) after `clear()`, or just `_buf = Buffer{}`